### PR TITLE
feat: Add daily briefing issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/daily-briefing.yml
+++ b/.github/ISSUE_TEMPLATE/daily-briefing.yml
@@ -1,0 +1,58 @@
+# .github/ISSUE_TEMPLATE/daily-briefing.yml
+
+name: 📝 업무 현황 브리핑 작성
+description: 2~3일간의 업무 현황을 브리핑 템플릿에 맞춰 작성합니다.
+title: "[브리핑] YYYY.MM.DD ~ YYYY.MM.DD"
+labels: ["briefing", "documentation"]
+assignees: ''
+
+body:
+  - type: input
+    id: briefing-scope
+    attributes:
+      label: ■ 브리핑 범위
+      description: 이 보고서가 다루는 시간의 범위를 명시합니다. [cite_start](예: 2025. 06. 18 (수) ~ 2025. 06. 19 (목)) [cite: 25]
+      placeholder: "YYYY.MM.DD (요일) ~ YYYY.MM.DD (요일)"
+    validations:
+      required: true
+
+  - type: input
+    id: author
+    attributes:
+      label: ■ 작성자
+      [cite_start]description: PM의 이름을 명시하여 책임과 신뢰를 보여줍니다. [cite: 27]
+      placeholder: "김진우 PM"
+    validations:
+      required: true
+      
+  - type: textarea
+    id: updates-summary
+    attributes:
+      label: "1. 최신 업데이트 요약 (Latest Updates)"
+      [cite_start]description: "지난 브리핑 이후 새롭게 완료/결정된 핵심 사항을 공유합니다.  아래 태그와 형식을 지켜주세요."
+      value: |
+        > * **(완료)** > * **(진행)** > * **(결정)** > * **(이슈)** validations:
+      required: true
+
+  - type: textarea
+    id: progress-details
+    attributes:
+      label: "2. 파트별 상세 현황 (Detailed Progress by Function)"
+      [cite_start]description: "각 파트의 구체적인 진행 상황을 기록합니다.  아래 템플릿의 각 항목에 내용을 채워주세요."
+      value: |
+        #### 🎨 디자인 (Design)
+        * **[진행 업무]** * **▪️ 목표 및 기대효과:** * **▪️ 최근 진행 내용:** * * **▪️ 이슈 또는 블로커:** ---
+        #### 💻 프론트엔드 (Frontend)
+        * **[진행 업무]** * **▪️ 목표 및 기대효과:** * **▪️ 최근 진행 내용:** * * **▪️ 이슈 또는 블로커:** ---
+        #### 🗄️ 백엔드 (Backend)
+        * **[진행 업무]** * **▪️ 목표 및 기대효과:** * **▪️ 최근 진행 내용:** * * **▪️ 이슈 또는 블로커:** validations:
+      required: true
+
+  - type: textarea
+    id: next-steps
+    attributes:
+      label: "3. 단기 계획 및 협조 요청 (Immediate Next Steps & Coordination)"
+      [cite_start]description: "다음 브리핑까지 진행될 일과, 파트 간 필요한 협조사항을 명확히 합니다.  (To. 대상) 형식을 지켜주세요. "
+      value: |
+        * **(To. 전체)** * **(To. 디자인)** * **(To. 프론트엔드)** * **(To. 백엔드)** validations:
+      required: true


### PR DESCRIPTION
feat: 📝 업무 현황 브리핑 이슈 템플릿 추가
📝 개요
팀의 비정기적/주기적 업무 보고 방식을 표준화하고, '지능형 브리핑 자동화 시스템' 구축 전까지 효율적인 소통 체계를 마련하기 위해 GitHub 이슈 폼(Issue Form)을 이용한 '업무 현황 브리핑' 템플릿을 추가합니다. 


💻 작업 내용
.github/ISSUE_TEMPLATE 디렉토리 구조를 생성했습니다.
daily-briefing.yml 파일을 추가하여, 'PM을 위한 실전 워크플로우' 가이드에 명시된 템플릿을 기반으로 이슈 폼을 구현했습니다. 
템플릿에는 다음과 같은 입력 필드가 포함됩니다:
브리핑 범위, 작성자 

최신 업데이트 요약 (완료, 진행, 결정, 이슈) 

파트별 상세 현황 (디자인, 프론트엔드, 백엔드) 
단기 계획 및 협조 요청 
🖼️ 스크린샷
[여기에 스크린샷을 첨부하세요]

촬영 안내: GitHub Repository의 Issues 탭 -> New issue 버튼을 클릭했을 때, 아래와 같이 📝 업무 현황 브리핑 작성 옵션이 보이는 화면을 캡처하여 첨부하면 됩니다.

&lt;- 예시 이미지입니다. 실제 캡처 화면으로 교체해주세요.

💬 리뷰어에게
YAML 파일의 문법에 오류가 없는지 확인 부탁드립니다.
New issue 버튼을 눌러 템플릿을 선택했을 때, 각 필드(특히 description과 value)가 의도한 대로 잘 표시되는지 검토해주세요. 팀원들이 가이드를 보고 쉽게 작성할 수 있을지 피드백 주시면 감사하겠습니다.
✅ 참고 사항
이 작업은 'Project Atlas' 시스템 구현을 위한 기반 설정의 일부입니다. 